### PR TITLE
Some fixes, and get intermodule javadoc links working

### DIFF
--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -164,7 +164,7 @@ function executeReport(report, locale)
 		"-docencoding",         report.outputEncoding,
 		"-doctitle",            title,
 		"-link",                jdklink,
-		"-sourcetab",           "4",
+		//"-sourcetab",         "4", // seemed good idea but implies -linksource
 		"-use",
 		"-version",
 		"-windowtitle",         title

--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -70,7 +70,7 @@
 			<plugin>
 				<groupId>org.postgresql</groupId>
 				<artifactId>pljava-pgxs</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
+				<version>${pljava.pgxs.version}</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -10,35 +10,6 @@
 	<name>PL/Java API</name>
 	<description>The API for Java stored procedures in PostgreSQL using PL/Java</description>
 
-	<profiles>
-		<profile>
-			<id>nashorngone</id>
-			<activation>
-				<jdk>[15,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.postgresql</groupId>
-						<artifactId>pljava-pgxs</artifactId>
-						<dependencies>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js-scriptengine</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-						</dependencies>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -138,8 +138,7 @@ function isExternalReport(report)
 function executeReport(report, locale)
 {
 	var paths = buildPaths(report.project.compileClasspathElements);
-	var classpath = paths['classpath'];
-	warn(classpath);
+	var classpath = paths.get('classpath');
 
 	var title = report.project.name + " " + report.project.version;
 

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -34,33 +34,6 @@
 				</plugins>
 			</build>
 		</profile>
-
-		<profile>
-			<id>nashorngone</id>
-			<activation>
-				<jdk>[15,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.postgresql</groupId>
-						<artifactId>pljava-pgxs</artifactId>
-						<dependencies>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js-scriptengine</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-						</dependencies>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 
 	<dependencies>
@@ -70,6 +43,7 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -208,7 +208,7 @@ function executeReport(report, locale)
 	var v = java.lang.Runtime.version();
 	if ( 0 <= v.compareTo(java.lang.Runtime.Version.parse("15-ea")) )
 		args.addAll(of("-linkoffline",
-			"../../pljava-api/apidocs", apioffline.toString()));
+			"../../RELDOTS/pljava-api/apidocs", apioffline.toString()));
 
 	var packages = [
 		"org.postgresql.pljava.example",
@@ -249,7 +249,8 @@ function executeReport(report, locale)
 			java.nio.charset.Charset.forName(report.inputEncoding)
 		);
 
-	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(smgr);
+	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(
+		smgr, java.nio.charset.Charset.forName(report.outputEncoding));
 	rmgr.handleFirstOptions(args);
 
 	var task = tool.getTask(null, rmgr, diagListener, null, args, null);

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -242,7 +242,17 @@ function executeReport(report, locale)
 		diag(d.kind, s + d.getMessage(locale));
 	}
 
-	var task = tool.getTask(null, null, diagListener, null, args, null);
+	var smgr = tool.getStandardFileManager(
+			diagListener,
+			locale,
+			java.nio.charset.Charset.forName(report.inputEncoding)
+		);
+
+	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(smgr);
+	rmgr.handleOption("-sourcepath",  of(srcroot.toString()).iterator());
+	rmgr.handleOption("-classpath",  of(classpath).iterator());
+
+	var task = tool.getTask(null, rmgr, diagListener, null, args, null);
 	task.call();
 }
 ]]>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -168,8 +168,12 @@ function executeReport(report, locale)
 		/*
 		 * The 'standard options' that javadoc inherits from javac.
 		 * Do not add --release: it causes -encoding to be ignored (in javadoc
-		 * 12 through 15, anyway).
+		 * 12 through 15, anyway). -d is documented as a doclet option, but
+		 * included here to be seen by the RelativizingFileManager (which may
+		 * otherwise complain that no class output location has been set).
 		 */
+		"-d",           report.reportOutputDirectory.toPath()
+							.resolve("apidocs").toString(),
 		"-encoding",    report.inputEncoding,
 		"--class-path", paths.get("classpath"),
 		"--module-path",paths.get("modulepath"),
@@ -188,8 +192,6 @@ function executeReport(report, locale)
 		 */
 		"-author",
 		"-bottom",      bottom,
-		"-d",           report.reportOutputDirectory.toPath()
-							.resolve("apidocs").toString(),
 		"-docencoding", report.outputEncoding,
 		"-doctitle",    title,
 		"-link",        jdklink,
@@ -243,14 +245,22 @@ function executeReport(report, locale)
 		diag(d.kind, s + d.getMessage(locale));
 	}
 
+	var Charset = Java.type("java.nio.charset.Charset");
+
 	var smgr = tool.getStandardFileManager(
 			diagListener,
 			locale,
-			java.nio.charset.Charset.forName(report.inputEncoding)
+			Charset.forName(report.inputEncoding)
 		);
 
+	/*
+	 * A special file manager that will rewrite the RELDOTS seen in -linkoffline
+	 * above. The options a file manager recognizes must be the first ones in
+	 * args; handleFirstOptions below returns at the first one the file manager
+	 * doesn't know what to do with.
+	 */
 	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(
-		smgr, java.nio.charset.Charset.forName(report.outputEncoding));
+		smgr, Charset.forName(report.outputEncoding));
 	rmgr.handleFirstOptions(args);
 
 	var task = tool.getTask(null, rmgr, diagListener, null, args, null);

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -138,7 +138,6 @@ function isExternalReport(report)
 function executeReport(report, locale)
 {
 	var paths = buildPaths(report.project.compileClasspathElements);
-	var classpath = paths.get('classpath');
 
 	var title = report.project.name + " " + report.project.version;
 
@@ -172,8 +171,10 @@ function executeReport(report, locale)
 		 * 12 through 15, anyway).
 		 */
 		"-encoding",    report.inputEncoding,
-		"-classpath",   classpath,
+		"--class-path", paths.get("classpath"),
+		"--module-path",paths.get("modulepath"),
 		"-sourcepath",  srcroot.toString(),
+		"--add-modules","org.postgresql.pljava",
 		/*
 		 * Core javadoc options.
 		 * Avoid the legacy package/private/protected/public options; they can

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -104,7 +104,7 @@
 			<plugin>
 				<groupId>org.postgresql</groupId>
 				<artifactId>pljava-pgxs</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
+				<version>${pljava.pgxs.version}</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -174,13 +174,14 @@ function executeReport(report, locale)
 		"--class-path", paths.get("classpath"),
 		"--module-path",paths.get("modulepath"),
 		"-sourcepath",  srcroot.toString(),
+		// ^^^ Options recognized by the file manager end here ^^^
 		"--add-modules","org.postgresql.pljava",
 		/*
 		 * Core javadoc options.
 		 * Avoid the legacy package/private/protected/public options; they can
 		 * clobber the effects of the newer -show-...=... options.
 		 */
-		"-locale",              locale.toString(),
+		"-locale",      locale.toString(),
 		"-quiet",
 		/*
 		 * Options that are passed to the doclet.
@@ -249,8 +250,7 @@ function executeReport(report, locale)
 		);
 
 	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(smgr);
-	rmgr.handleOption("-sourcepath",  of(srcroot.toString()).iterator());
-	rmgr.handleOption("-classpath",  of(classpath).iterator());
+	rmgr.handleFirstOptions(args);
 
 	var task = tool.getTask(null, rmgr, diagListener, null, args, null);
 	task.call();

--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -105,7 +105,7 @@
 			<plugin>
 				<groupId>org.postgresql</groupId>
 				<artifactId>pljava-pgxs</artifactId>
-				<version>1.6.0-SNAPSHOT</version>
+				<version>${pljava.pgxs.version}</version>
 				<executions>
 					<execution>
 						<id>execute-script</id>

--- a/pljava-pgxs/pom.xml
+++ b/pljava-pgxs/pom.xml
@@ -22,22 +22,6 @@
 			<version>${maven.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>${maven.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-compat</artifactId>
-			<version>${maven.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 			<version>3.6.0</version>
@@ -53,6 +37,27 @@
 			<version>3.0</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>nashorngone</id>
+			<activation>
+				<jdk>[15,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.graalvm.js</groupId>
+					<artifactId>js</artifactId>
+					<version>20.1.0</version>
+				</dependency>
+				<dependency>
+					<groupId>org.graalvm.js</groupId>
+					<artifactId>js-scriptengine</artifactId>
+					<version>20.1.0</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>
@@ -81,5 +86,139 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.postgresql</groupId>
+				<artifactId>pljava-pgxs</artifactId>
+				<version>${project.version}</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>
+								scripting-report
+							</report>
+						</reports>
+						<configuration>
+							<script mimetype="application/javascript">
+<![CDATA[
+function getName(report, locale)
+{
+	return "JavaDocs";
+}
+
+function getDescription(report, locale)
+{
+	return "JavaDoc API documentation.";
+}
+
+function getOutputName(report)
+{
+	return java.nio.file.Paths.get("apidocs", "index").toString();
+}
+
+function isExternalReport(report)
+{
+	return true;
+}
+
+function executeReport(report, locale)
+{
+	var paths = buildPaths(report.project.compileClasspathElements);
+
+	var title = report.project.name + " " + report.project.version;
+
+	var basedir = report.project.basedir.toPath();
+
+	/*
+	 * The toString() here is a sop to a graaljs bug; nashorn doesn't need it.
+	 */
+	var srcroot = java.nio.file.Paths.get("src", "main", "java").toString();
+	srcroot = basedir.resolve(srcroot);
+	var srcrooturi = srcroot.toUri();
+
+	var jdklink = "https://docs.oracle.com/" +
+		locale.language + "/java/javase/12/docs/api";
+
+	var bottom =
+		"Copyright &#169; " +
+		report.project.inceptionYear + "&#x2013;" + new Date().getFullYear() +
+		"<a href='" + report.project.organization.url + "'>" +
+		report.project.organization.name + "</a>";
+
+	var of = java.util.List.of;
+
+	var args = of(
+		/*
+		 * The 'standard options' that javadoc inherits from javac.
+		 * Do not add --release: it causes -encoding to be ignored (in javadoc
+		 * 12 through 15, anyway). -d is documented as a doclet option, but
+		 * included here to be seen by the RelativizingFileManager (which may
+		 * otherwise complain that no class output location has been set).
+		 */
+		"-d",           report.reportOutputDirectory.toPath()
+							.resolve("apidocs").toString(),
+		"-encoding",    report.inputEncoding,
+		"--class-path", paths.get("classpath"),
+		"--module-path",paths.get("modulepath"),
+		"-sourcepath",  srcroot.toString(),
+		/*
+		 * Core javadoc options.
+		 * Avoid the legacy package/private/protected/public options; they can
+		 * clobber the effects of the newer -show-...=... options.
+		 */
+		"-locale",      locale.toString(),
+		"-quiet",
+		/*
+		 * Options that are passed to the doclet.
+		 */
+		"-author",
+		"-bottom",      bottom,
+		"-docencoding", report.outputEncoding,
+		"-doctitle",    title,
+		"-link",        jdklink,
+		"-use",
+		"-version",
+		"-windowtitle", title
+	);
+
+	args = new java.util.ArrayList(args);
+
+	var packages = [
+		"org.postgresql.pljava.pgxs"
+	];
+
+	packages.forEach(function(p) { args.add(p); });
+
+	debug(args.toString());
+	var tool = javax.tools.ToolProvider.getSystemDocumentationTool();
+
+	function diagListener(d)
+	{
+		var s = d.source;
+
+		if ( null === s )
+			s = "";
+		else
+		{
+			s = srcrooturi.relativize(s.toUri()).toString();
+			s += "[" + d.lineNumber + "," + d.columnNumber + "] ";
+		}
+
+		diag(d.kind, s + d.getMessage(locale));
+	}
+
+	var task = tool.getTask(null, null, diagListener, null, args, null);
+	task.call();
+}
+]]>
+							</script>
+						</configuration>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
 
 </project>

--- a/pljava-pgxs/pom.xml
+++ b/pljava-pgxs/pom.xml
@@ -15,11 +15,6 @@
 	<description>The maven plugin to build native code used inside PL/Java
 	</description>
 
-	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -83,13 +78,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<release>9</release>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
@@ -370,7 +370,7 @@ public final class PGXSUtils
 			return Files.exists(moduleInfoFile);
 		}
 
-		if (path.endsWith(".jar"))
+		if (path.getFileName().toString().endsWith(".jar"))
 		{
 			try(JarFile jarFile = new JarFile(path.toFile()))
 			{

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
@@ -377,7 +377,6 @@ public final class PGXSUtils
 				if (jarFile.getEntry("module-info.class") != null)
 					return true;
 				Manifest manifest = jarFile.getManifest();
-				jarFile.close();
 				if (manifest == null)
 					return false;
 				return manifest.getMainAttributes()

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
@@ -147,7 +147,10 @@ implements StandardJavaFileManager
 			stream(getLocationAsPaths(location).spliterator(), false)
 			.filter(p -> fp.startsWith(p)).findAny().get();
 
-		int depth = r.relativize(fp).getNameCount() - 1;
+		int depth = r.relativize(fp).getNameCount() - 1; // -1 for file name
+
+		if ( location.isModuleOrientedLocation() )
+			++ depth;
 
 		final String dots = Stream.generate(() -> "../").limit(depth)
 			.collect(Collectors.joining());

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
@@ -12,27 +12,180 @@
 
 package org.postgresql.pljava.pgxs;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
 
 import java.nio.file.Path;
 
 import java.util.Collection;
 import java.util.Iterator;
 
+import java.util.regex.Pattern;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import static java.util.stream.StreamSupport.stream;
+
+import javax.tools.DocumentationTool; // mentioned in javadoc
 import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
+import javax.tools.ForwardingJavaFileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
+import static javax.tools.JavaFileObject.Kind.HTML;
 import javax.tools.StandardJavaFileManager;
 
+/**
+ * A {@link ForwardingJavaFileManager} that interposes when asked for an output
+ * file of type {@code HTML}, and rewrites {@code href} URLs that contain
+ * {@code RELDOTS} as a component.
+ *<h2>Purpose</h2>
+ *<p>
+ * This file manager is intended for use with the {@link DocumentationTool}
+ * when {@code -linkoffline} is used to generate links between subprojects
+ * (for example, {@code pljava-examples} to {@code pljava-api}). Maven's
+ * {@code site:stage} will copy the generated per-subproject documentation trees
+ * into a single {@code staging} directory, which can be relocated, deployed to
+ * web servers, etc. Therefore, it is both reasonable and desirable for the
+ * subproject API docs to refer to each other by relative links. However, the
+ * documentation for {@code -linkoffline} states that the relative links should
+ * be given as if from the output destination ({@code -d}) directory. That
+ * implies that the tool will add the right number of {@code ../} components,
+ * when generating links in a file some levels below the {@code -d} directory,
+ * so that the resulting relative URL will be correct. And it doesn't. The tool
+ * simply doesn't.
+ *<p>
+ * As a workaround, the {@code -linkoffline} option can be told to produce URLs
+ * that contain {@code RELDOTS}, for example,
+ * {@code ../../RELDOTS/pljava-api/apidocs}, and this file manager can be used
+ * when running the tool. As the HTML files are written, any {@code href} URL
+ * that begins with zero or more {@code ../} followed by {@code RELDOTS} will
+ * have the {@code RELDOTS} replaced with the right number of {@code ../} to
+ * ascend from that file's containing directory to the output destination
+ * directory, resulting in relative URLs that are correct in files at any depth
+ * in the API docs tree.
+ *<p>
+ * An alert reader will notice that {@code RELDOTS} is expanded to exactly what
+ * {@code {@docRoot}} is supposed to expand to. But experiment showed that
+ * {@code {@docRoot}} does not get expanded in a {@code -linkoffline} URL.
+ *<h2>Limitations</h2>
+ * The postprocessing is done blindly to any rules of HTML syntax. It will
+ * simply replace {@code RELDOTS} in any substring of the content resembling
+ * <code>href=&quot;../RELDOTS/</code> (with any number, zero or more, of
+ * {@code ../} before the {@code RELDOTS}). The example in the preceding
+ * sentence was written carefully to avoid being rewritten in this comment.
+ *<p>
+ * Only the form with a double quote is recognized, as the javadoc tool does not
+ * appear to generate the single-quoted form.
+ */
 public class RelativizingFileManager
 extends ForwardingJavaFileManager<StandardJavaFileManager>
 implements StandardJavaFileManager
 {
-	public RelativizingFileManager(StandardJavaFileManager fileManager)
+	private final Charset outputEncoding;
+
+	/**
+	 * Construct a {@code RelativizingFileManager}, given the underlying file
+	 * manager from {@link DocumentationTool#getStandardFileManager}, and the
+	 * output encoding to be used.
+	 *<p>
+	 * The javadoc tool requests {@link OutputStream}s for its output files, and
+	 * supplies content already encoded, so the encoding is needed in order to
+	 * decode them here for simple processing (as {@code java.util.regex} does
+	 * not offer byte-domain flavors of patterns and matchers), then re-encode
+	 * the result.
+	 *<p>
+	 * The file manager constructed here must still be configured by passing
+	 * the necessary subset of the desired javadoc options to
+	 * {@link #handleFirstOptions handleFirstOptions}.
+	 */
+	public RelativizingFileManager(
+		StandardJavaFileManager fileManager,
+		Charset outputEncoding)
 	{
 		super(fileManager);
+		this.outputEncoding = outputEncoding;
+	}
+
+	static final Pattern toReplace = Pattern.compile(
+		"(\\shref=\"(?:\\.\\./)*+)RELDOTS/");
+
+	/**
+	 * Overridden to return the superclass result unchanged unless the requested
+	 * file is of kind {@code HTML}, and in that case to return a file object
+	 * that will interpose on the {@code OutputStream} and apply the rewriting.
+	 */
+	@Override
+	public FileObject getFileForOutput(
+		Location location /* location */,
+		String packageName,
+		String relativePath,
+		FileObject sibling)
+	throws IOException
+	{
+		FileObject fo = fileManager.getFileForOutput(
+			location, packageName, relativePath, sibling);
+		if ( ! (fo instanceof JavaFileObject) )
+			return fo;
+		JavaFileObject jfo = (JavaFileObject)fo;
+		if ( ! (HTML == jfo.getKind()) )
+			return fo;
+
+		Path fp = asPath(fo);
+		Path r =
+			stream(getLocationAsPaths(location).spliterator(), false)
+			.filter(p -> fp.startsWith(p)).findAny().get();
+
+		int depth = r.relativize(fp).getNameCount() - 1;
+
+		final String dots = Stream.generate(() -> "../").limit(depth)
+			.collect(Collectors.joining());
+
+		return new ForwardingJavaFileObject(jfo)
+		{
+			@Override
+			public OutputStream openOutputStream() throws IOException
+			{
+				final OutputStream os = fileObject.openOutputStream();
+
+				return new ByteArrayOutputStream()
+				{
+					private boolean closed = false;
+
+					@Override
+					public void close() throws IOException
+					{
+						if ( closed )
+							return;
+						closed = true;
+						super.close();
+
+						try (os; Writer w =
+							new OutputStreamWriter(os,
+								outputEncoding.newEncoder()))
+						{
+							ByteBuffer bb = ByteBuffer.wrap(buf, 0, count);
+							CharBuffer cb =
+								outputEncoding.newDecoder().decode(bb);
+							String fixed = toReplace.matcher(cb).replaceAll(
+								"$1" + dots);
+							w.append(fixed);
+						}
+					}
+				};
+			}
+		};
 	}
 
 	/**
@@ -60,7 +213,11 @@ implements StandardJavaFileManager
 	}
 
 	/*
-	 * The boilerplate StandardJavaFileManager forwards follow.
+	 * The file manager supplied by the tool is an instance of
+	 * StandardJavaFileManager. There is no forwarding version of that, so we
+	 * must extend ForwardingJavaFileManager and then supply forwarding versions
+	 * of all methods added in StandardJavaFileManager. Those boilerplate
+	 * forwarding methods follow.
 	 */
 
 	@Override

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
@@ -33,6 +34,34 @@ implements StandardJavaFileManager
 	{
 		super(fileManager);
 	}
+
+	/**
+	 * Call {@link #handleOption handleOption} on as many of the first supplied
+	 * options as the file manager recognizes.
+	 *<p>
+	 * Returns when {@link #handleOption handleOption} first returns false,
+	 * indicating an option the file manager does not recognize.
+	 *<p>
+	 * As the options recognized by the standard file manager are generally
+	 * those among the "Standard Options" that javadoc inherits from javac
+	 * (including the various location-setting options such as
+	 * {@code -classpath}, as well as {@code -encoding}), with a little care to
+	 * place those first in the argument list to be passed to the tool itself,
+	 * the same list can be passed to this method to configure the file manager,
+	 * without any more complicated option recognition needed here.
+	 */
+	public void handleFirstOptions(Iterable<String> firstOptions)
+	{
+		Iterator<String> it = firstOptions.iterator();
+
+		while ( it.hasNext() )
+			if ( ! handleOption(it.next(), it) )
+				break;
+	}
+
+	/*
+	 * The boilerplate StandardJavaFileManager forwards follow.
+	 */
 
 	@Override
 	public Iterable<? extends JavaFileObject>

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
@@ -41,6 +41,13 @@ implements StandardJavaFileManager
 		return fileManager.getJavaFileObjectsFromFiles(files);
 	}
 
+	// @Override only when support horizon advances to >= Java 13
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjectsFromPaths(Collection<? extends Path> paths)
+	{
+		return fileManager.getJavaFileObjectsFromPaths(paths);
+	}
+
 	@Override
 	public Iterable<? extends JavaFileObject>
 	getJavaFileObjectsFromPaths(Iterable<? extends Path> paths)

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/RelativizingFileManager.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+
+package org.postgresql.pljava.pgxs;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.Path;
+
+import java.util.Collection;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+
+public class RelativizingFileManager
+extends ForwardingJavaFileManager<StandardJavaFileManager>
+implements StandardJavaFileManager
+{
+	public RelativizingFileManager(StandardJavaFileManager fileManager)
+	{
+		super(fileManager);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjectsFromFiles(Iterable<? extends File> files)
+	{
+		return fileManager.getJavaFileObjectsFromFiles(files);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjectsFromPaths(Iterable<? extends Path> paths)
+	{
+		return fileManager.getJavaFileObjectsFromPaths(paths);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjects(File... files)
+	{
+		return fileManager.getJavaFileObjects(files);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjects(Path... paths)
+	{
+		return fileManager.getJavaFileObjects(paths);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjectsFromStrings(Iterable<String> names)
+	{
+		return fileManager.getJavaFileObjectsFromStrings(names);
+	}
+
+	@Override
+	public Iterable<? extends JavaFileObject>
+	getJavaFileObjects(String... names)
+	{
+		return fileManager.getJavaFileObjects(names);
+	}
+
+	@Override
+	public void setLocation(Location location, Iterable<? extends File> files)
+	throws IOException
+	{
+		fileManager.setLocation(location, files);
+	}
+
+	@Override
+	public void setLocationFromPaths(
+		Location location,
+		Collection<? extends Path> paths)
+	throws IOException
+	{
+		fileManager.setLocationFromPaths(location, paths);
+	}
+
+	@Override
+	public void setLocationForModule(
+		Location location,
+        String moduleName,
+        Collection<? extends Path> paths)
+	throws IOException
+	{
+		fileManager.setLocationForModule(location, moduleName, paths);
+	}
+
+	@Override
+	public Iterable<? extends File> getLocation(Location location)
+	{
+		return fileManager.getLocation(location);
+	}
+
+	@Override
+	public Iterable<? extends Path> getLocationAsPaths(Location location)
+	{
+		return fileManager.getLocationAsPaths(location);
+	}
+
+	@Override
+	public Path asPath(FileObject file)
+	{
+		return fileManager.asPath(file);
+	}
+
+	@Override
+	public void setPathFactory(PathFactory f)
+	{
+		fileManager.setPathFactory(f);
+	}
+}

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -304,7 +304,7 @@
 			<plugin>
 				<groupId>org.postgresql</groupId>
 				<artifactId>pljava-pgxs</artifactId>
-				<version>1.6.0-SNAPSHOT</version>
+				<version>${pljava.pgxs.version}</version>
 				<executions>
 					<execution>
 						<id>execute-script</id>

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -116,10 +116,7 @@ function isExternalReport(report)
 
 function executeReport(report, locale)
 {
-	var pljava_api_jar_path;
-	for each (var artifact in report.project.artifacts)
-		if (artifact.artifactId == "pljava-api")
-			pljava_api_jar_path = artifact.file.path;
+	var paths = buildPaths(report.project.compileClasspathElements);
 
 	var title = report.project.name + " " + report.project.version;
 
@@ -152,7 +149,7 @@ function executeReport(report, locale)
 		 */
 		"-encoding",              report.inputEncoding,
 		"--module",               "org.postgresql.pljava.internal",
-		"--module-path",          pljava_api_jar_path,
+		"--module-path",          paths.get("modulepath"),
 		"--module-source-path",   "org.postgresql.pljava.internal=" + srcroot,
 		/*
 		 * Core javadoc options.

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -17,35 +17,6 @@
 		</dependency>
 	</dependencies>
 
-	<profiles>
-		<profile>
-			<id>nashorngone</id>
-			<activation>
-				<jdk>[15,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.postgresql</groupId>
-						<artifactId>pljava-pgxs</artifactId>
-						<dependencies>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js-scriptengine</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-						</dependencies>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -145,12 +145,17 @@ function executeReport(report, locale)
 		/*
 		 * The 'standard options' that javadoc inherits from javac.
 		 * Do not add --release: it causes -encoding to be ignored (in javadoc
-		 * 12 through 15, anyway).
+		 * 12 through 15, anyway). -d is documented as a doclet option, but
+		 * included here to be seen by the RelativizingFileManager (which may
+		 * otherwise complain that no class output location has been set).
 		 */
+		"-d",                     report.reportOutputDirectory.toPath()
+									.resolve("apidocs").toString(),
 		"-encoding",              report.inputEncoding,
-		"--module",               "org.postgresql.pljava.internal",
 		"--module-path",          paths.get("modulepath"),
 		"--module-source-path",   "org.postgresql.pljava.internal=" + srcroot,
+		// ^^^ Options recognized by the file manager end here ^^^
+		"--module",               "org.postgresql.pljava.internal",
 		/*
 		 * Core javadoc options.
 		 * Avoid the legacy package/private/protected/public options; they can
@@ -165,13 +170,11 @@ function executeReport(report, locale)
 		 */
 		"-author",
 		"-bottom",                bottom,
-		"-d",                     report.reportOutputDirectory.toPath()
-									.resolve("apidocs").toString(),
 		"-docencoding",           report.outputEncoding,
 		"-doctitle",              title,
 		"-link",                  jdklink,
 		"-linkoffline",
-								  "../../pljava-api/apidocs",
+								  "../../RELDOTS/pljava-api/apidocs",
 								  apioffline.toString(),
 		"-sourcetab",             "4",
 		"-use",
@@ -197,7 +200,25 @@ function executeReport(report, locale)
 		diag(d.kind, s + d.getMessage(locale));
 	}
 
-	var task = tool.getTask(null, null, diagListener, null, args, null);
+	var Charset = Java.type("java.nio.charset.Charset");
+
+	var smgr = tool.getStandardFileManager(
+			diagListener,
+			locale,
+			Charset.forName(report.inputEncoding)
+		);
+
+	/*
+	 * A special file manager that will rewrite the RELDOTS seen in -linkoffline
+	 * above. The options a file manager recognizes must be the first ones in
+	 * args; handleFirstOptions below returns at the first one the file manager
+	 * doesn't know what to do with.
+	 */
+	var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(
+		smgr, Charset.forName(report.outputEncoding));
+	rmgr.handleFirstOptions(args);
+
+	var task = tool.getTask(null, rmgr, diagListener, null, args, null);
 	task.call();
 }
 ]]>

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -176,7 +176,7 @@ function executeReport(report, locale)
 		"-linkoffline",
 								  "../../RELDOTS/pljava-api/apidocs",
 								  apioffline.toString(),
-		"-sourcetab",             "4",
+		//"-sourcetab",           "4",//seemed good idea but implies -linksource
 		"-use",
 		"-version",
 		"-windowtitle",           title

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -68,7 +68,7 @@
 			<plugin>
 				<groupId>org.postgresql</groupId>
 				<artifactId>pljava-pgxs</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
+				<version>${pljava.pgxs.version}</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 	<description>Java stored procedures for PostgreSQL</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<pljava.pgxs.version>${project.version}</pljava.pgxs.version>
 	</properties>
 
 	<organization>


### PR DESCRIPTION
A few fixes in the first five commits, then get the javadoc links between `pljava-` submodules working in relative form, something that has bothered me for years. Making them relative allows the documentation tree to be moved around, opens the possibility to have multiple versions accessible on the web, etc.

The `javadoc` tool seems to work very hard to make generating such relative links just about impossible. 2763035 predicted that getting them working was going to be a headache. It was.
